### PR TITLE
Add data-plane namespace permission

### DIFF
--- a/microservices/gatewayApi/v1/services/namespaces.py
+++ b/microservices/gatewayApi/v1/services/namespaces.py
@@ -6,7 +6,7 @@ from clients.keycloak import admin_api
 
 class NamespaceService:
     std_attrs = []
-    priv_attrs = ['perm-domains', 'perm-protected-ns']
+    priv_attrs = ['perm-domains', 'perm-protected-ns', 'perm-data-plane']
 
     def __init__(self):
         self.keycloak_admin = admin_api()

--- a/microservices/gatewayApi/v2/services/namespaces.py
+++ b/microservices/gatewayApi/v2/services/namespaces.py
@@ -6,7 +6,7 @@ from clients.keycloak import admin_api
 
 class NamespaceService:
     std_attrs = []
-    priv_attrs = ['perm-domains', 'perm-protected-ns']
+    priv_attrs = ['perm-domains', 'perm-protected-ns', 'perm-data-plane']
 
     def __init__(self):
         self.keycloak_admin = admin_api()


### PR DESCRIPTION
What data plane a namespace can deploy to is a new namespace-level permission that has been added to Keycloak Group Attributes.  The attribute is `perm-data-plane` and can have only one value.  The value represents the Kubernetes Service of the particular data plane.

It is used by the `gatewayApi` and the `jobScheduler` to decide which `kubeApi` to call, in order to update the edge Route on the Kubernetes cluster that the data plane is running on.