### PR TITLE
kong upstream jwt plugin defaults

### DIFF
--- a/microservices/gatewayApi/entrypoint.sh
+++ b/microservices/gatewayApi/entrypoint.sh
@@ -45,6 +45,11 @@ cat > "${CONFIG_PATH:-./config/default.json}" <<EOF
             "redis_password": "${PLUGINS_RATELIMITING_REDIS_PASSWORD}",
             "redis_timeout": 2000
         },
+        "upstream_jwt": {
+            "key_id": "${UPSTREAM_JWT_KEY_ID}",
+            "private_key_location": "${UPSTREAM_JWT_PRIVATE_KEY_FILE}",
+            "public_key_location": "${UPSTREAM_JWT_PUBLIC_KEY_FILE}"
+        },
         "proxy_cache": {
             "strategy": "memory",
             "memory": { "dictionary_name": "${PLUGINS_PROXYCACHE_MEMORY_DICT:-"aps_proxy_cache"}" }

--- a/microservices/gatewayApi/entrypoint.sh
+++ b/microservices/gatewayApi/entrypoint.sh
@@ -47,6 +47,7 @@ cat > "${CONFIG_PATH:-./config/default.json}" <<EOF
         },
         "upstream_jwt": {
             "key_id": "${PLUGINS_UPSTREAM_JWT_KEY_ID}",
+            "issuer": "${PLUGINS_UPSTREAM_JWT_ISSUER}",
             "private_key_location": "${PLUGINS_UPSTREAM_JWT_PRIVATE_KEY_FILE}",
             "public_key_location": "${PLUGINS_UPSTREAM_JWT_PUBLIC_KEY_FILE}"
         },

--- a/microservices/gatewayApi/entrypoint.sh
+++ b/microservices/gatewayApi/entrypoint.sh
@@ -46,9 +46,9 @@ cat > "${CONFIG_PATH:-./config/default.json}" <<EOF
             "redis_timeout": 2000
         },
         "upstream_jwt": {
-            "key_id": "${UPSTREAM_JWT_KEY_ID}",
-            "private_key_location": "${UPSTREAM_JWT_PRIVATE_KEY_FILE}",
-            "public_key_location": "${UPSTREAM_JWT_PUBLIC_KEY_FILE}"
+            "key_id": "${PLUGINS_UPSTREAM_JWT_KEY_ID}",
+            "private_key_location": "${PLUGINS_UPSTREAM_JWT_PRIVATE_KEY_FILE}",
+            "public_key_location": "${PLUGINS_UPSTREAM_JWT_PUBLIC_KEY_FILE}"
         },
         "proxy_cache": {
             "strategy": "memory",

--- a/microservices/gatewayApi/utils/transforms.py
+++ b/microservices/gatewayApi/utils/transforms.py
@@ -21,6 +21,19 @@ def proxy_cache (plugin, plugin_configs=None):
     for k, v in override_config.items():
         plugin_config[k] = v
 
+def upstream_jwt (plugin, plugin_configs=None):
+    override_config = conf['plugins']['upstream_jwt']
+
+    if 'config' in plugin:
+        plugin_config = plugin['config']
+    else:
+        plugin['config'] = {}
+        plugin_config = plugin['config']
+
+    for k, v in override_config.items():
+        plugin_config[k] = v
+
+
 def rate_limiting (plugin, plugin_configs=None):
     override_config = conf['plugins']['rate_limiting']
 
@@ -77,6 +90,8 @@ def traverse_plugins (yaml, plugin_configs = None):
                         rate_limiting(item, plugin_configs)
                     elif item['name'] == 'proxy-cache':
                         proxy_cache(item, plugin_configs)
+                    elif item['name'] == 'kong-upstream-jwt':
+                        upstream_jwt(item, plugin_configs)
                 traverse_plugins (item, plugin_configs)
     
 


### PR DESCRIPTION
The `kong-upstream-jwt` plugin has various settings that would not be known by the API Provider and therefore must be automatically configured when the plugin is created.  This change defines the defaults that will get set.