### PR TITLE
Refactor Keycloak integration in gatewayJobScheduler

### DIFF
--- a/microservices/gatewayJobScheduler/README.md
+++ b/microservices/gatewayJobScheduler/README.md
@@ -1,4 +1,4 @@
-# Kube API
+# Gateway Scheduler API
 
 ## Getting Started
 

--- a/microservices/gatewayJobScheduler/app.py
+++ b/microservices/gatewayJobScheduler/app.py
@@ -4,7 +4,6 @@ import traceback
 from clients.namespace import NamespaceService
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
-from clients.keycloak import admin_api
 
 logger = logging.getLogger(__name__)
 
@@ -85,9 +84,9 @@ def _get_certificate_for_host(host, namespace, cert_snis, certs):
             
     raise Exception("Certificate not found for host %s" % host)
 
-def transform_data_by_ns(routes, certs, cert_snis):
+def transform_data_by_ns(kc, routes, certs, cert_snis):
     """Transform route data organized by namespace"""
-    ns_svc = NamespaceService()
+    ns_svc = NamespaceService(kc)
     try:
         ns_dict = {}
         ns_attr_dict = {}
@@ -132,13 +131,12 @@ def transform_data_by_ns(routes, certs, cert_snis):
     except Exception as err:
         traceback.print_exc()
         logger.error("Error transforming data. %s" % str(err))
-        return {}
+        raise
 
-def get_namespaces_with_perm_data_plane(perm_data_plane_value):
+def get_namespaces_with_perm_data_plane(kc, perm_data_plane_value):
     """
     Fetch namespaces from Keycloak group 'ns' with attribute perm-data-plane matching the given value
     """
-    kc = admin_api()
     namespaces = []
     # Find the 'ns' group
     ns_groups = kc.get_groups()

--- a/microservices/gatewayJobScheduler/clients/namespace.py
+++ b/microservices/gatewayJobScheduler/clients/namespace.py
@@ -1,22 +1,13 @@
-from clients.keycloak import admin_api
-from keycloak.exceptions import KeycloakGetError
-
 class NamespaceService:
 
-    def __init__(self):
-        self.keycloak_admin = admin_api()
+    def __init__(self, keycloak_admin):
+        self.keycloak_admin = keycloak_admin
 
     def get_namespace_attributes(self, namespace):
-        try:
-            ns_group_summary = self.keycloak_admin.get_group_by_path(
-                path="/%s/%s" % ('ns', namespace))
-        except KeycloakGetError:
-            return {}
+        ns_group_summary = self.keycloak_admin.get_group_by_path(
+            path="/%s/%s" % ('ns', namespace))
         if ns_group_summary is not None:
-            try:
-                ns_group = self.keycloak_admin.get_group(ns_group_summary['id'])
-            except KeycloakGetError:
-                return {}
+            ns_group = self.keycloak_admin.get_group(ns_group_summary['id'])
             attrs = ns_group.get('attributes', {})
             return attrs
         return {}

--- a/microservices/gatewayJobScheduler/main.py
+++ b/microservices/gatewayJobScheduler/main.py
@@ -4,8 +4,8 @@ from sys import exc_info
 import logging
 import traceback
 from app import transform_data_by_ns, get_namespaces_with_perm_data_plane
+from clients.keycloak import admin_api
 from clients.kong import get_records
-import traceback
 import schedule
 from schedule import every, repeat, run_pending, clear
 import time
@@ -15,6 +15,11 @@ logging.basicConfig(level=os.getenv('LOG_LEVEL', default=logging.DEBUG),
                     format='%(asctime)s-%(levelname)s-%(message)s', datefmt='%d-%b-%y %H:%M:%S')
 
 logger = logging.getLogger(__name__)
+
+def validate_keycloak_connection(kc):
+    """Verify Keycloak connectivity before performing any sync operations"""
+    kc.get_groups(query={"max": 1})
+    logger.info("Keycloak connection validated")
 
 @repeat(every(int(os.getenv('SYNC_INTERVAL'))).seconds.tag('sync-routes'))
 def sync_routes():
@@ -33,18 +38,37 @@ def sync_routes():
         clear('sync-routes')
         exit(1)
 
-    # Get Gold namespaces from Keycloak
-    perm_data_plane_value = os.getenv('DATA_PLANE')
-    namespaces = get_namespaces_with_perm_data_plane(perm_data_plane_value)
+    try:
+        kc = admin_api()
+        validate_keycloak_connection(kc)
+    except Exception:
+        traceback.print_exc()
+        logger.error('Failed to connect to Keycloak')
+        clear('sync-routes')
+        exit(1)
 
-    data = transform_data_by_ns(routes, certs, cert_snis)
-    if data is None:
-        data = {}
+    try:
+        # Get Gold namespaces from Keycloak
+        perm_data_plane_value = os.getenv('DATA_PLANE')
+        namespaces = get_namespaces_with_perm_data_plane(kc, perm_data_plane_value)
+        # Transform route data from Kong
+        data = transform_data_by_ns(kc, routes, certs, cert_snis)
+    except Exception as err:
+        traceback.print_exc()
+        logger.error('Failed to process namespace/route data - %s' % str(err))
+        clear('sync-routes')
+        exit(1)
 
     # Add missing namespaces with no routes
     for ns in namespaces:
         if ns not in data:
             data[ns] = []
+
+    if len(routes) > 0 and all(len(v) == 0 for v in data.values()):
+        logger.error(
+            "Kong has %d routes but transformation produced zero route entries — aborting sync" % len(routes))
+        clear('sync-routes')
+        exit(1)
 
     for ns in data:
         url = os.getenv('KUBE_API_URL') + '/namespaces/%s/routes/sync' % ns

--- a/microservices/gatewayJobScheduler/poetry.lock
+++ b/microservices/gatewayJobScheduler/poetry.lock
@@ -770,4 +770,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "4b7e2159bb2a4544cefcce6f8864c4c10397bf1285ac8f6d940f8156cb91d877"
+content-hash = "b58ca5e13f703c2acaf993a41d1f84a3a1f7037d1b1225d75f33832c0d9c58af"

--- a/microservices/gatewayJobScheduler/pyproject.toml
+++ b/microservices/gatewayJobScheduler/pyproject.toml
@@ -13,7 +13,7 @@ python-keycloak = "4.7.3"
 httpx = ">=0.23.2,<0.28"
 cryptography = "^43.0.3"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 autopep8 = "^1.5.7"
 python-dotenv = "^0.19.1"
 pytest = "^8.2.0"

--- a/microservices/gatewayJobScheduler/tests/conftest.py
+++ b/microservices/gatewayJobScheduler/tests/conftest.py
@@ -47,7 +47,13 @@ os.environ.update({
 
 mock_keycloak_admin = mock.Mock()
 keycloak_exceptions = types.ModuleType('keycloak.exceptions')
-keycloak_exceptions.KeycloakGetError = type('KeycloakGetError', (Exception,), {})
+
+class _MockKeycloakGetError(Exception):
+    def __init__(self, *args, response_code=None, **kwargs):
+        super().__init__(*args)
+        self.response_code = response_code
+
+keycloak_exceptions.KeycloakGetError = _MockKeycloakGetError
 sys.modules['keycloak.exceptions'] = keycloak_exceptions
 keycloak_module = types.ModuleType('keycloak')
 keycloak_module.KeycloakOpenIDConnection = mock.Mock()

--- a/microservices/gatewayJobScheduler/tests/test_get_namespaces_with_perm_data_plane.py
+++ b/microservices/gatewayJobScheduler/tests/test_get_namespaces_with_perm_data_plane.py
@@ -35,7 +35,7 @@ def test_get_namespaces_with_perm_data_plane_happy_path(mock_keycloak_clients):
         ]
     }
     
-    result = get_namespaces_with_perm_data_plane('test-dp')
+    result = get_namespaces_with_perm_data_plane(mock_kc, 'test-dp')
     
     assert result == ['namespace1', 'namespace2']
     mock_kc.get_groups.assert_called_once()
@@ -51,7 +51,7 @@ def test_get_namespaces_with_perm_data_plane_no_ns_group(mock_keycloak_clients):
         {'id': 'group2', 'name': 'another-group'}
     ]
     
-    result = get_namespaces_with_perm_data_plane('test-dp')
+    result = get_namespaces_with_perm_data_plane(mock_kc, 'test-dp')
     
     assert result == []
     mock_kc.get_groups.assert_called_once()
@@ -68,7 +68,7 @@ def test_get_namespaces_with_perm_data_plane_no_subgroups(mock_keycloak_clients)
     # Mock empty subgroups
     mock_kc.get_group.return_value = {'subGroups': []}
     
-    result = get_namespaces_with_perm_data_plane('test-dp')
+    result = get_namespaces_with_perm_data_plane(mock_kc, 'test-dp')
     
     assert result == []
     mock_kc.get_group.assert_called_once_with('ns-group-id')
@@ -98,7 +98,7 @@ def test_get_namespaces_with_perm_data_plane_no_matching_namespaces(mock_keycloa
         ]
     }
     
-    result = get_namespaces_with_perm_data_plane('test-dp')
+    result = get_namespaces_with_perm_data_plane(mock_kc, 'test-dp')
     
     assert result == []
 
@@ -138,7 +138,7 @@ def test_get_namespaces_with_perm_data_plane_missing_attributes(mock_keycloak_cl
         ]
     }
     
-    result = get_namespaces_with_perm_data_plane('test-dp')
+    result = get_namespaces_with_perm_data_plane(mock_kc, 'test-dp')
     
     assert result == ['namespace1']
 
@@ -153,6 +153,6 @@ def test_get_namespaces_with_perm_data_plane_missing_subgroups_key(mock_keycloak
     # Mock response without subGroups key
     mock_kc.get_group.return_value = {}
     
-    result = get_namespaces_with_perm_data_plane('test-dp')
+    result = get_namespaces_with_perm_data_plane(mock_kc, 'test-dp')
     
     assert result == []

--- a/microservices/gatewayJobScheduler/tests/test_transform_data_by_ns.py
+++ b/microservices/gatewayJobScheduler/tests/test_transform_data_by_ns.py
@@ -4,109 +4,149 @@ from unittest import mock
 from app import transform_data_by_ns
 from conftest import SAMPLE_CERT, SAMPLE_KEY
 
-def test_happy_transform_data_by_ns():
-    with mock.patch('clients.namespace.admin_api') as mock_admin_api:
-        set_mock_admin_api_response(mock_admin_api)
 
-        routes = [
-            {
-                "name": "route-1",
-                "tags": [ "ns.ns1"],
-                "hosts": [
-                    "test.api.gov.bc.ca"
-                ]
-            }
-        ]
-        certs = []
-        cert_snis = []
-        expected_value = {
-            "ns1": [
-                {
-                    "name": "wild-ns-ns1-test.api.gov.bc.ca",
-                    "selectTag": "ns.ns1",
-                    "host": "test.api.gov.bc.ca",
-                    "sessionCookieEnabled": False,
-                    "dataClass": None,
-                    "dataPlane": "test-dp",
-                    "sslCertificateSerialNumber": None,
-                    "certificates": None
-                }
+def _create_mock_kc():
+    mock_kc = mock.Mock()
+    mock_kc.get_group_by_path.return_value = {"id": "group-1"}
+    mock_kc.get_group.return_value = {
+        "attributes": {
+            "perm-data-plane": ["test-dp"]
+        }
+    }
+    return mock_kc
+
+
+def test_happy_transform_data_by_ns():
+    mock_kc = _create_mock_kc()
+    routes = [
+        {
+            "name": "route-1",
+            "tags": [ "ns.ns1"],
+            "hosts": [
+                "test.api.gov.bc.ca"
             ]
         }
-        assert json.dumps(transform_data_by_ns(routes, certs, cert_snis)) == json.dumps(expected_value)
-
-def test_happy_transform_data_by_ns_with_override_session_cookie():
-    with mock.patch('clients.namespace.admin_api') as mock_admin_api:
-        set_mock_admin_api_response(mock_admin_api)
-
-        routes = [
+    ]
+    certs = []
+    cert_snis = []
+    expected_value = {
+        "ns1": [
             {
-                "name": "route-1",
-                "tags": [ "ns.ns1", "aps.route.session.cookie.enabled"],
-                "hosts": [
-                    "test.api.gov.bc.ca"
-                ]
-            }
-        ]
-        certs = []
-        cert_snis = []
-        expected_value = {
-            "ns1": [{
-                "name": "wild-ns-ns1-test.api.gov.bc.ca",
-                "selectTag": "ns.ns1",
-                "host": "test.api.gov.bc.ca",
-                "sessionCookieEnabled": True,
-                "dataClass": None,
-                "dataPlane": "test-dp",
-                "sslCertificateSerialNumber": None,
-                "certificates": None
-            }]
-        }
-        assert json.dumps(transform_data_by_ns(routes, certs, cert_snis)) == json.dumps(expected_value)
-
-def test_happy_transform_data_by_ns_with_override_data_plane():
-    with mock.patch('clients.namespace.admin_api') as mock_admin_api:
-        set_mock_admin_api_response(mock_admin_api)
-
-        routes = [
-            {
-                "name": "route-1",
-                "tags": [ "ns.ns1", "aps.route.dataclass.high"],
-                "hosts": [
-                    "test.api.gov.bc.ca"
-                ]
-            }
-        ]
-        certs = []
-        cert_snis = []
-        expected_value = {
-            "ns1": [{
                 "name": "wild-ns-ns1-test.api.gov.bc.ca",
                 "selectTag": "ns.ns1",
                 "host": "test.api.gov.bc.ca",
                 "sessionCookieEnabled": False,
-                "dataClass": "high",
+                "dataClass": None,
                 "dataPlane": "test-dp",
                 "sslCertificateSerialNumber": None,
                 "certificates": None
-            }]
-        }
-        assert json.dumps(transform_data_by_ns(routes, certs, cert_snis)) == json.dumps(expected_value)
-
-def test_happy_transform_data_by_ns_with_custom_domain():
-    with mock.patch('clients.namespace.admin_api') as mock_admin_api:
-        set_mock_admin_api_response(mock_admin_api)
-
-        routes = [
-            {
-                "name": "route-1",
-                "tags": [ "ns.ns1"],
-                "hosts": [
-                    "test.custom.gov.bc.ca"
-                ]
             }
         ]
-        certs = [
+    }
+    assert json.dumps(transform_data_by_ns(mock_kc, routes, certs, cert_snis)) == json.dumps(expected_value)
+
+
+def test_happy_transform_data_by_ns_with_override_session_cookie():
+    mock_kc = _create_mock_kc()
+    routes = [
+        {
+            "name": "route-1",
+            "tags": [ "ns.ns1", "aps.route.session.cookie.enabled"],
+            "hosts": [
+                "test.api.gov.bc.ca"
+            ]
+        }
+    ]
+    certs = []
+    cert_snis = []
+    expected_value = {
+        "ns1": [{
+            "name": "wild-ns-ns1-test.api.gov.bc.ca",
+            "selectTag": "ns.ns1",
+            "host": "test.api.gov.bc.ca",
+            "sessionCookieEnabled": True,
+            "dataClass": None,
+            "dataPlane": "test-dp",
+            "sslCertificateSerialNumber": None,
+            "certificates": None
+        }]
+    }
+    assert json.dumps(transform_data_by_ns(mock_kc, routes, certs, cert_snis)) == json.dumps(expected_value)
+
+
+def test_happy_transform_data_by_ns_with_override_data_plane():
+    mock_kc = _create_mock_kc()
+    routes = [
+        {
+            "name": "route-1",
+            "tags": [ "ns.ns1", "aps.route.dataclass.high"],
+            "hosts": [
+                "test.api.gov.bc.ca"
+            ]
+        }
+    ]
+    certs = []
+    cert_snis = []
+    expected_value = {
+        "ns1": [{
+            "name": "wild-ns-ns1-test.api.gov.bc.ca",
+            "selectTag": "ns.ns1",
+            "host": "test.api.gov.bc.ca",
+            "sessionCookieEnabled": False,
+            "dataClass": "high",
+            "dataPlane": "test-dp",
+            "sslCertificateSerialNumber": None,
+            "certificates": None
+        }]
+    }
+    assert json.dumps(transform_data_by_ns(mock_kc, routes, certs, cert_snis)) == json.dumps(expected_value)
+
+
+def test_happy_transform_data_by_ns_with_custom_domain():
+    mock_kc = _create_mock_kc()
+    routes = [
+        {
+            "name": "route-1",
+            "tags": [ "ns.ns1"],
+            "hosts": [
+                "test.custom.gov.bc.ca"
+            ]
+        }
+    ]
+    certs = [
+            {
+                "id": "41d14845-669f-4dcd-aff2-926fb32a4b25",
+                "cert": SAMPLE_CERT,
+                "created_at": 1731713874,
+                "tags": [
+                    "ns.ns1"
+                ],
+                "key": SAMPLE_KEY,
+            }
+    ]
+    cert_snis = [
+        {
+            "name": "test.custom.gov.bc.ca",
+            "id": "79009c9e-0f4d-40b5-9707-bf2fe9f50502",
+            "created_at": 1731713874,
+            "certificate": {
+                "id": "41d14845-669f-4dcd-aff2-926fb32a4b25"
+            },
+            "tags": [
+                "ns.ns1"
+            ]
+        }
+    ]
+    expected_value = {
+        "ns1": [{
+            "name": "wild-ns-ns1-test.custom.gov.bc.ca",
+            "selectTag": "ns.ns1",
+            "host": "test.custom.gov.bc.ca",
+            "sessionCookieEnabled": False,
+            "dataClass": None,
+            "dataPlane": "test-dp",
+            "sslCertificateSerialNumber": "1",
+            "certificates": [
                 {
                     "id": "41d14845-669f-4dcd-aff2-926fb32a4b25",
                     "cert": SAMPLE_CERT,
@@ -115,101 +155,51 @@ def test_happy_transform_data_by_ns_with_custom_domain():
                         "ns.ns1"
                     ],
                     "key": SAMPLE_KEY,
+                    "snis": [
+                        "test.custom.gov.bc.ca"
+                    ]
                 }
-        ]
-        cert_snis = [
-            {
-                "name": "test.custom.gov.bc.ca",
-                "id": "79009c9e-0f4d-40b5-9707-bf2fe9f50502",
-                "created_at": 1731713874,
-                "certificate": {
-                    "id": "41d14845-669f-4dcd-aff2-926fb32a4b25"
-                },
-                "tags": [
-                    "ns.ns1"
-                ]
-            }
-        ]
-        expected_value = {
-            "ns1": [{
-                "name": "wild-ns-ns1-test.custom.gov.bc.ca",
-                "selectTag": "ns.ns1",
-                "host": "test.custom.gov.bc.ca",
-                "sessionCookieEnabled": False,
-                "dataClass": None,
-                "dataPlane": "test-dp",
-                "sslCertificateSerialNumber": "1",
-                "certificates": [
-                    {
-                        "id": "41d14845-669f-4dcd-aff2-926fb32a4b25",
-                        "cert": SAMPLE_CERT,
-                        "created_at": 1731713874,
-                        "tags": [
-                            "ns.ns1"
-                        ],
-                        "key": SAMPLE_KEY,
-                        "snis": [
-                            "test.custom.gov.bc.ca"
-                        ]
-                    }
-                ]
-            }]
+            ]
+        }]
+    }
+    assert json.dumps(transform_data_by_ns(mock_kc, routes, certs, cert_snis)) == json.dumps(expected_value)
+
+
+def test_missing_cert_transform_data_by_ns_with_custom_domain():
+    mock_kc = _create_mock_kc()
+    routes = [
+        {
+            "name": "route-1",
+            "tags": [ "ns.ns1"],
+            "hosts": [
+                "test.custom.gov.bc.ca"
+            ]
         }
-        assert json.dumps(transform_data_by_ns(routes, certs, cert_snis)) == json.dumps(expected_value)
-
-def test_missing_cert_transform_data_by_ns_with_custom_domain(caplog):
-    with mock.patch('clients.namespace.admin_api') as mock_admin_api:
-        set_mock_admin_api_response(mock_admin_api)
-
-        routes = [
+    ]
+    certs = [
             {
-                "name": "route-1",
-                "tags": [ "ns.ns1"],
-                "hosts": [
-                    "test.custom.gov.bc.ca"
-                ]
-            }
-        ]
-        certs = [
-                {
-                    "id": "41d14845-669f-4dcd-aff2-926fb32a4b25",
-                    "cert": "CERT",
-                    "created_at": 1731713874,
-                    "tags": [
-                        "ns.ns1"
-                    ],
-                    "key": "KEY",
-                }
-        ]
-        cert_snis = [
-            {
-                "name": "other.custom.gov.bc.ca",
-                "id": "79009c9e-0f4d-40b5-9707-bf2fe9f50502",
+                "id": "41d14845-669f-4dcd-aff2-926fb32a4b25",
+                "cert": "CERT",
                 "created_at": 1731713874,
-                "certificate": {
-                    "id": "41d14845-669f-4dcd-aff2-926fb32a4b25"
-                },
                 "tags": [
                     "ns.ns1"
-                ]
+                ],
+                "key": "KEY",
             }
-        ]
-        
-        expected_error = "Error transforming data. Certificate not found for host test.custom.gov.bc.ca"
-        transform_data_by_ns(routes, certs, cert_snis)
-        assert expected_error in caplog.text
+    ]
+    cert_snis = [
+        {
+            "name": "other.custom.gov.bc.ca",
+            "id": "79009c9e-0f4d-40b5-9707-bf2fe9f50502",
+            "created_at": 1731713874,
+            "certificate": {
+                "id": "41d14845-669f-4dcd-aff2-926fb32a4b25"
+            },
+            "tags": [
+                "ns.ns1"
+            ]
+        }
+    ]
 
-
-def set_mock_admin_api_response(dt):
-    class mock_admin_api:
-        def get_group_by_path(path, **kwargs):
-            return {
-                "id": "group-1"
-            }
-        def get_group(id):
-            return {
-                "attributes": {
-                    "perm-data-plane": ["test-dp"]
-                }
-            }
-    dt.return_value = mock_admin_api
+    with pytest.raises(Exception, match="Certificate not found for host test.custom.gov.bc.ca"):
+        transform_data_by_ns(mock_kc, routes, certs, cert_snis)


### PR DESCRIPTION
- don't silence errors in namespace.py
- raise error if transform_data_by_ns hits an exception
- Use a single Keycloak admin instance.
- Added Keycloak connection validation in sync_routes function.
- add sanity check before syncing
- Updated tests to ensure proper mocking of Keycloak interactions.
