### PR TITLE
fix get_group_by_path 404 handling for Keycloak 26 compatibility

### DIFF
--- a/microservices/gatewayApi/clients/keycloak.py
+++ b/microservices/gatewayApi/clients/keycloak.py
@@ -18,3 +18,17 @@ def admin_api(conf):
 
     keycloak_admin = KeycloakAdmin(connection=keycloak_connection)
     return keycloak_admin
+
+
+def safe_get_group_by_path(keycloak_admin, path, **kwargs):
+    """Returns None when a group path doesn't exist, regardless of
+    python-keycloak version or Keycloak server version."""
+    try:
+        result = keycloak_admin.get_group_by_path(path, **kwargs)
+        if isinstance(result, dict) and "error" in result:
+            return None
+        return result
+    except KeycloakGetError as e:
+        if e.response_code == 404:
+            return None
+        raise

--- a/microservices/gatewayApi/templates/keycloak/client.json
+++ b/microservices/gatewayApi/templates/keycloak/client.json
@@ -39,7 +39,7 @@
         "saml.onetimeuse.condition": "false"
     },
     "authenticationFlowBindingOverrides": {},
-    "fullScopeAllowed": false,
+    "fullScopeAllowed": true,
     "nodeReRegistrationTimeout": -1,
     "protocolMappers": [
         {

--- a/microservices/gatewayApi/templates/keycloak/client.json
+++ b/microservices/gatewayApi/templates/keycloak/client.json
@@ -96,7 +96,13 @@
         }
     ],
     "defaultClientScopes": [
-        "role_list"
+        "role_list",
+        "profile",
+        "email",
+        "roles",
+        "acr",
+        "basic",
+        "web-origins"
     ],
     "optionalClientScopes": [],
     "access": {

--- a/microservices/gatewayApi/templates/keycloak/client.json
+++ b/microservices/gatewayApi/templates/keycloak/client.json
@@ -39,7 +39,7 @@
         "saml.onetimeuse.condition": "false"
     },
     "authenticationFlowBindingOverrides": {},
-    "fullScopeAllowed": true,
+    "fullScopeAllowed": false,
     "nodeReRegistrationTimeout": -1,
     "protocolMappers": [
         {
@@ -96,13 +96,7 @@
         }
     ],
     "defaultClientScopes": [
-        "role_list",
-        "profile",
-        "email",
-        "roles",
-        "acr",
-        "basic",
-        "web-origins"
+        "role_list"
     ],
     "optionalClientScopes": [],
     "access": {

--- a/microservices/gatewayApi/v1/routes/namespaces.py
+++ b/microservices/gatewayApi/v1/routes/namespaces.py
@@ -19,7 +19,7 @@ from v1.services.namespaces import NamespaceService, get_base_group_path
 
 from v1.auth.auth import admin_jwt, enforce_authorization, enforce_role_authorization, users_group_root, admins_group_root
 
-from clients.keycloak import admin_api
+from clients.keycloak import admin_api, safe_get_group_by_path
 from utils.validators import namespace_valid, namespace_validation_rule
 
 ns = Blueprint('namespaces', 'namespaces')
@@ -99,7 +99,7 @@ def delete_namespace(namespace: str) -> object:
 
     try:
         for role_name in ['viewer', 'admin']:
-            group = keycloak_admin.get_group_by_path("%s/%s" % (get_base_group_path(role_name), namespace))
+            group = safe_get_group_by_path(keycloak_admin, "%s/%s" % (get_base_group_path(role_name), namespace))
             if group is not None:
                 keycloak_admin.delete_group (group['id'])
 
@@ -149,12 +149,12 @@ def membership_sync (namespace, role_name, desired_membership_list):
 
     base_group_path = get_base_group_path (role_name)
 
-    group = keycloak_admin.get_group_by_path("%s/%s" % (base_group_path, namespace), search_in_subgroups=True)
+    group = safe_get_group_by_path(keycloak_admin, "%s/%s" % (base_group_path, namespace), search_in_subgroups=True)
 
     if group is None:
         log.warn("[%s] Group %s/%s Missing!" % (namespace, base_group_path, namespace))
         create_group (namespace, base_group_path, role_name)
-        group = keycloak_admin.get_group_by_path("%s/%s" % (base_group_path, namespace), search_in_subgroups=True)
+        group = safe_get_group_by_path(keycloak_admin, "%s/%s" % (base_group_path, namespace), search_in_subgroups=True)
 
     group = keycloak_admin.get_group (group['id'])
 
@@ -195,10 +195,10 @@ def create_group(namespace, group_base_path, role_name):
     log = app.logger
     keycloak_admin = admin_api()
 
-    parent_group = keycloak_admin.get_group_by_path(group_base_path)
+    parent_group = safe_get_group_by_path(keycloak_admin, group_base_path)
     if parent_group is None:
         keycloak_admin.create_group ({"name": get_base_group_name(role_name)})
-        parent_group = keycloak_admin.get_group_by_path(group_base_path)
+        parent_group = safe_get_group_by_path(keycloak_admin, group_base_path)
 
     keycloak_admin.create_group ({"name": namespace}, parent=parent_group['id'])
     log.debug("[%s] Group %s/%s created!", namespace, group_base_path, namespace)

--- a/microservices/gatewayApi/v1/routes/serviceaccounts.py
+++ b/microservices/gatewayApi/v1/routes/serviceaccounts.py
@@ -73,16 +73,23 @@ def create_service_account(namespace: str) -> object:
 
         # KC 26 may not honour defaultClientScopes from the JSON payload,
         # so explicitly assign the realm's default scopes to the new client.
-        realm = keycloak_admin.realm_name
-        default_scopes_raw = keycloak_admin.raw_get(
-            f"admin/realms/{realm}/default-default-client-scopes"
-        )
-        if default_scopes_raw.status_code == 200:
-            for scope in default_scopes_raw.json():
-                keycloak_admin.raw_put(
-                    f"admin/realms/{realm}/clients/{cuuid}/default-client-scopes/{scope['id']}",
-                    data=None,
-                )
+        try:
+            realm = keycloak_admin.realm_name
+            scopes_resp = keycloak_admin.raw_get(
+                f"admin/realms/{realm}/default-default-client-scopes"
+            )
+            log.info("GET realm default scopes: status=%s body=%s",
+                     scopes_resp.status_code, scopes_resp.text[:500])
+            if scopes_resp.status_code == 200:
+                for scope in scopes_resp.json():
+                    put_resp = keycloak_admin.raw_put(
+                        f"admin/realms/{realm}/clients/{cuuid}/default-client-scopes/{scope['id']}",
+                        json.dumps({})
+                    )
+                    log.info("PUT assign scope %s (%s): status=%s",
+                             scope.get('name', '?'), scope['id'], put_resp.status_code)
+        except Exception as scope_err:
+            log.warning("Failed to assign default client scopes to %s: %s", cid, scope_err)
 
         r = keycloak_admin.generate_client_secrets(cuuid)
         return ({'client_id': cid, 'client_secret': r['value']}, 201)

--- a/microservices/gatewayApi/v1/routes/serviceaccounts.py
+++ b/microservices/gatewayApi/v1/routes/serviceaccounts.py
@@ -70,6 +70,20 @@ def create_service_account(namespace: str) -> object:
     try:
         response = keycloak_admin.create_client (j)
         cuuid = keycloak_admin.get_client_id(cid)
+
+        # KC 26 may not honour defaultClientScopes from the JSON payload,
+        # so explicitly assign the realm's default scopes to the new client.
+        realm = keycloak_admin.realm_name
+        default_scopes_raw = keycloak_admin.raw_get(
+            f"admin/realms/{realm}/default-default-client-scopes"
+        )
+        if default_scopes_raw.status_code == 200:
+            for scope in default_scopes_raw.json():
+                keycloak_admin.raw_put(
+                    f"admin/realms/{realm}/clients/{cuuid}/default-client-scopes/{scope['id']}",
+                    data=None,
+                )
+
         r = keycloak_admin.generate_client_secrets(cuuid)
         return ({'client_id': cid, 'client_secret': r['value']}, 201)
     except KeycloakGetError as err:

--- a/microservices/gatewayApi/v1/routes/serviceaccounts.py
+++ b/microservices/gatewayApi/v1/routes/serviceaccounts.py
@@ -70,27 +70,6 @@ def create_service_account(namespace: str) -> object:
     try:
         response = keycloak_admin.create_client (j)
         cuuid = keycloak_admin.get_client_id(cid)
-
-        # KC 26 may not honour defaultClientScopes from the JSON payload,
-        # so explicitly assign the realm's default scopes to the new client.
-        try:
-            realm = keycloak_admin.realm_name
-            scopes_resp = keycloak_admin.raw_get(
-                f"admin/realms/{realm}/default-default-client-scopes"
-            )
-            log.info("GET realm default scopes: status=%s body=%s",
-                     scopes_resp.status_code, scopes_resp.text[:500])
-            if scopes_resp.status_code == 200:
-                for scope in scopes_resp.json():
-                    put_resp = keycloak_admin.raw_put(
-                        f"admin/realms/{realm}/clients/{cuuid}/default-client-scopes/{scope['id']}",
-                        json.dumps({})
-                    )
-                    log.info("PUT assign scope %s (%s): status=%s",
-                             scope.get('name', '?'), scope['id'], put_resp.status_code)
-        except Exception as scope_err:
-            log.warning("Failed to assign default client scopes to %s: %s", cid, scope_err)
-
         r = keycloak_admin.generate_client_secrets(cuuid)
         return ({'client_id': cid, 'client_secret': r['value']}, 201)
     except KeycloakGetError as err:
@@ -145,4 +124,3 @@ def delete_service_account(namespace: str, client_id: str) -> object:
     except KeycloakGetError as err:
         log.error(err)
         abort(make_response(jsonify(error="Failed to delete service account"), 400))
-

--- a/microservices/gatewayApi/v1/services/namespaces.py
+++ b/microservices/gatewayApi/v1/services/namespaces.py
@@ -13,8 +13,8 @@ class NamespaceService:
 
     def get_namespace(self, namespace):
         group_base_path = get_base_group_path('viewer')
-        ns_group_summary = safe_get_group_by_path(
-            self.keycloak_admin, "%s/%s" % (group_base_path, namespace))
+        self.keycloak_admin.get_group_by_path(
+            path="%s/%s" % (group_base_path, namespace))
         ns_group = self.keycloak_admin.get_group(ns_group_summary['id'])
         return ns_group
 

--- a/microservices/gatewayApi/v1/services/namespaces.py
+++ b/microservices/gatewayApi/v1/services/namespaces.py
@@ -1,7 +1,7 @@
 from v1.auth.auth import users_group_root, admins_group_root
 from flask import current_app as app
 from v1.auth.auth import admin_jwt
-from clients.keycloak import admin_api
+from clients.keycloak import admin_api, safe_get_group_by_path
 
 
 class NamespaceService:
@@ -13,8 +13,8 @@ class NamespaceService:
 
     def get_namespace(self, namespace):
         group_base_path = get_base_group_path('viewer')
-        ns_group_summary = self.keycloak_admin.get_group_by_path(
-            path="%s/%s" % (group_base_path, namespace))
+        ns_group_summary = safe_get_group_by_path(
+            self.keycloak_admin, "%s/%s" % (group_base_path, namespace))
         ns_group = self.keycloak_admin.get_group(ns_group_summary['id'])
         return ns_group
 
@@ -39,10 +39,10 @@ class NamespaceService:
         for role_name in ['viewer', 'admin']:
 
             group_base_path = get_base_group_path(role_name)
-            parent_group = self.keycloak_admin.get_group_by_path(group_base_path)
+            parent_group = safe_get_group_by_path(self.keycloak_admin, group_base_path)
             if parent_group is None:
                 self.keycloak_admin.create_group({"name": get_base_group_name(role_name)})
-                parent_group = self.keycloak_admin.get_group_by_path(group_base_path)
+                parent_group = safe_get_group_by_path(self.keycloak_admin, group_base_path)
 
             new_users_group_id = self.keycloak_admin.create_group(payload, parent=parent_group['id'])
             log.debug("[%s] Group %s/%s created!" % (namespace, group_base_path, namespace))

--- a/microservices/gatewayApi/v1/services/namespaces.py
+++ b/microservices/gatewayApi/v1/services/namespaces.py
@@ -13,7 +13,7 @@ class NamespaceService:
 
     def get_namespace(self, namespace):
         group_base_path = get_base_group_path('viewer')
-        self.keycloak_admin.get_group_by_path(
+        ns_group_summary = self.keycloak_admin.get_group_by_path(
             path="%s/%s" % (group_base_path, namespace))
         ns_group = self.keycloak_admin.get_group(ns_group_summary['id'])
         return ns_group

--- a/microservices/gatewayApi/v2/services/namespaces.py
+++ b/microservices/gatewayApi/v2/services/namespaces.py
@@ -1,7 +1,7 @@
 from v1.auth.auth import users_group_root, admins_group_root
 from flask import current_app as app
 from v1.auth.auth import admin_jwt
-from clients.keycloak import admin_api
+from clients.keycloak import admin_api, safe_get_group_by_path
 
 
 class NamespaceService:
@@ -15,8 +15,8 @@ class NamespaceService:
 
     def get_namespace(self, namespace):
         group_base_path = get_base_group_path('viewer')
-        ns_group_summary = self.keycloak_admin.get_group_by_path(
-            path="%s/%s" % (group_base_path, namespace))
+        ns_group_summary = safe_get_group_by_path(
+            self.keycloak_admin, "%s/%s" % (group_base_path, namespace))
         ns_group = self.keycloak_admin.get_group(ns_group_summary['id'])
         return ns_group
 
@@ -41,10 +41,10 @@ class NamespaceService:
         for role_name in ['viewer']:
 
             group_base_path = get_base_group_path(role_name)
-            parent_group = self.keycloak_admin.get_group_by_path(group_base_path)
+            parent_group = safe_get_group_by_path(self.keycloak_admin, group_base_path)
             if parent_group is None:
                 self.keycloak_admin.create_group({"name": get_base_group_name(role_name)})
-                parent_group = self.keycloak_admin.get_group_by_path(group_base_path)
+                parent_group = safe_get_group_by_path(self.keycloak_admin, group_base_path)
 
             new_users_group_id = self.keycloak_admin.create_group(payload, parent=parent_group['id'])
             log.debug("[%s] Group %s/%s created!" % (namespace, group_base_path, namespace))

--- a/microservices/gatewayApi/v2/services/namespaces.py
+++ b/microservices/gatewayApi/v2/services/namespaces.py
@@ -15,8 +15,8 @@ class NamespaceService:
 
     def get_namespace(self, namespace):
         group_base_path = get_base_group_path('viewer')
-        ns_group_summary = safe_get_group_by_path(
-            self.keycloak_admin, "%s/%s" % (group_base_path, namespace))
+        ns_group_summary = self.keycloak_admin.get_group_by_path(
+            path="%s/%s" % (group_base_path, namespace))
         ns_group = self.keycloak_admin.get_group(ns_group_summary['id'])
         return ns_group
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Keycloak 26 changed `GET /admin/realms/{realm}/group-by-path/{path}` to return **HTTP 404** when a group path doesn't exist, instead of a response that `python-keycloak` translated to `None`. This broke namespace bootstrapping - `init-kong-batch-job` silently failed to create the `platform` namespace because the 404 either raised an unhandled `KeycloakGetError` or returned an `{"error": ...}` dict (depending on `python-keycloak` version), neither of which matched the existing `is None` checks.


## Types of changes

- Added a `safe_get_group_by_path` wrapper in `clients/keycloak.py` that normalizes the behavior: it catches 404 `KeycloakGetError` exceptions and detects error-dict responses, returning `None` in both cases.
- Replaced all 8 direct `get_group_by_path` calls across `v1/services/namespaces.py`, `v1/routes/namespaces.py`, and `v2/services/namespaces.py` with the safe wrapper.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (non-breaking change with enhancements to documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
