### PR TITLE
cleanup the action type

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,8 +1,8 @@
 on:
   # Trigger analysis when pushing in master or pull requests, and when creating
-  # a pull request. 
+  # a pull request.
   pull_request:
-      types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened]
   push:
     branches:
       - master
@@ -11,12 +11,12 @@ jobs:
   sonarcloud:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        # Disabling shallow clone is recommended for improving relevancy of reporting
-        fetch-depth: 0
-    - name: SonarCloud Scan
-      uses: sonarsource/sonarcloud-github-action@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      - uses: actions/checkout@v2
+        with:
+          # Disabling shallow clone is recommended for improving relevancy of reporting
+          fetch-depth: 0
+      - name: SonarCloud Scan
+        uses: sonarsource/sonarqube-scan-action@v8.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/microservices/gatewayApi/v1/routes/gateway.py
+++ b/microservices/gatewayApi/v1/routes/gateway.py
@@ -432,7 +432,7 @@ def write_config(namespace: str) -> object:
         message = "Dry-run.  No changes applied."
 
     if cmd == 'sync':
-        record_gateway_event(event_id, 'published', 'completed', namespace, blob=orig_config)
+        record_gateway_event(event_id, 'publish', 'completed', namespace, blob=orig_config)
 
     results = mask(out.decode('utf-8'))
     

--- a/microservices/gatewayApi/v2/routes/gateway.py
+++ b/microservices/gatewayApi/v2/routes/gateway.py
@@ -452,7 +452,7 @@ def write_config(namespace: str) -> object:
         message = "Dry-run.  No changes applied."
 
     if cmd == 'sync':
-        record_gateway_event(event_id, 'published', 'completed', namespace, blob=orig_config)
+        record_gateway_event(event_id, 'publish', 'completed', namespace, blob=orig_config)
 
     results = mask(out.decode('utf-8'))
     


### PR DESCRIPTION

**Background:**

APS-4532 is wanting to make the set of valid Activity `action` types correct, and `published` was an action type that gwa-api publishes, but should really be `publish` to be consistent with the tense that the action type is represented with.
