### PR TITLE
APS-4665 resource list for gateway and optional consumers

### DIFF
--- a/microservices/gatewayApi/Dockerfile
+++ b/microservices/gatewayApi/Dockerfile
@@ -15,18 +15,25 @@ WORKDIR /app
 
 RUN apk add build-base libffi-dev openssl openssl-dev curl
 
-RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl" && \
+# TARGETARCH is amd64/arm64 from BuildKit (docker buildx / compose build)
+ARG TARGETARCH
+
+RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${TARGETARCH}/kubectl" && \
     chmod +x kubectl; mv kubectl /usr/local/bin/.
 
 #COPY --from=build /deck/deck /usr/local/bin
 
-# gwa api (kong 2)
-RUN curl -sL https://github.com/kong/deck/releases/download/v1.5.0/deck_1.5.0_linux_amd64.tar.gz -o deck.tar.gz && \
-   tar -xf deck.tar.gz -C /tmp && \
-   cp /tmp/deck /usr/local/bin/deck_kong2_150
+# gwa api (kong 2) — v1.5.0 has no linux_arm64 release
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+      curl -sL https://github.com/kong/deck/releases/download/v1.5.0/deck_1.5.0_linux_amd64.tar.gz -o deck.tar.gz && \
+      tar -xf deck.tar.gz -C /tmp && \
+      cp /tmp/deck /usr/local/bin/deck_kong2_150; \
+    else \
+      echo "Skipping deck_kong2_150 on ${TARGETARCH} (no upstream arm64 release for v1.5.0)"; \
+    fi
 
 # gwa api (kong 3)
-RUN curl -sL https://github.com/Kong/deck/releases/download/v1.53.1/deck_1.53.1_linux_amd64.tar.gz -o deck.tar.gz && \
+RUN curl -sL https://github.com/Kong/deck/releases/download/v1.53.1/deck_1.53.1_linux_${TARGETARCH}.tar.gz -o deck.tar.gz && \
    tar -xf deck.tar.gz -C /tmp && \
    cp /tmp/deck /usr/local/bin/deck && \
    cp /tmp/deck /usr/local/bin/deck_kong3_1531

--- a/microservices/gatewayApi/clients/kong.py
+++ b/microservices/gatewayApi/clients/kong.py
@@ -11,8 +11,8 @@ def get_routes ():
 def get_plugins ():
     return recurse_get_records ([], "/plugins")
 
-def get_tagged_resources_by_ns (ns, base_url = None):
-    return recurse_get_records ([], "/tags/" + quote("ns.%s" % ns), base_url=base_url)
+def get_tagged_resources_by_tag (tag, base_url = None):
+    return recurse_get_records ([], "/tags/" + quote(tag), base_url=base_url)
 
 def get_services_by_ns (ns):
     return recurse_get_records ([], "/services?tags=ns.%s" % ns)

--- a/microservices/gatewayApi/clients/kong.py
+++ b/microservices/gatewayApi/clients/kong.py
@@ -1,6 +1,6 @@
 from flask import current_app as app
 import requests
-import urllib.parse
+from urllib.parse import quote, quote_plus
 
 # Access the Kong Admin API for details about the Kong configuration
 #
@@ -10,6 +10,9 @@ def get_routes ():
 
 def get_plugins ():
     return recurse_get_records ([], "/plugins")
+
+def get_tagged_resources_by_ns (ns):
+    return recurse_get_records ([], "/tags/" + quote("ns.%s" % ns))
 
 def get_services_by_ns (ns):
     return recurse_get_records ([], "/services?tags=ns.%s" % ns)

--- a/microservices/gatewayApi/clients/kong.py
+++ b/microservices/gatewayApi/clients/kong.py
@@ -11,8 +11,8 @@ def get_routes ():
 def get_plugins ():
     return recurse_get_records ([], "/plugins")
 
-def get_tagged_resources_by_ns (ns):
-    return recurse_get_records ([], "/tags/" + quote("ns.%s" % ns))
+def get_tagged_resources_by_ns (ns, base_url = None):
+    return recurse_get_records ([], "/tags/" + quote("ns.%s" % ns), base_url=base_url)
 
 def get_services_by_ns (ns):
     return recurse_get_records ([], "/services?tags=ns.%s" % ns)
@@ -41,9 +41,12 @@ def get_acls ():
 def get_consumer (consumer_id):
     return get_record ([], "/consumers/%s" % consumer_id)
 
-def recurse_get_records (result, url):
+def recurse_get_records (result, url, base_url = None):
     log = app.logger
-    admin_url = app.config['kongAdminUrl']
+    if base_url is None:
+        admin_url = app.config['kongAdminUrl']
+    else:
+        admin_url = base_url
 
     log.debug("%s%s" % (admin_url, url))
     r = requests.get("%s%s" % (admin_url, url))
@@ -52,7 +55,7 @@ def recurse_get_records (result, url):
     result.extend(data)
 
     if json['next'] is not None:
-        recurse_get_records (result, json['next'])
+        recurse_get_records (result, json['next'], base_url=admin_url)
     return result
 
 def get_record (result, url):

--- a/microservices/gatewayApi/utils/deck.py
+++ b/microservices/gatewayApi/utils/deck.py
@@ -1,5 +1,5 @@
 
-def deck_cmd_sync_diff(deck_cli, cmd, select_tag, state, kong_addr = None, allow_consumers = True):
+def deck_cmd_sync_diff(deck_cli, cmd, select_tag, state, kong_addr = None, allow_consumers = False):
     if deck_cli == "deck" or deck_cli.startswith("deck_kong3_"):
         args = [ deck_cli, "gateway", cmd, "--config", "/tmp/deck.yaml", "--select-tag", select_tag]
         if kong_addr:

--- a/microservices/gatewayApi/utils/deck.py
+++ b/microservices/gatewayApi/utils/deck.py
@@ -1,9 +1,11 @@
 
-def deck_cmd_sync_diff(deck_cli, cmd, select_tag, state, kong_addr = None):
+def deck_cmd_sync_diff(deck_cli, cmd, select_tag, state, kong_addr = None, allow_consumers = True):
     if deck_cli == "deck" or deck_cli.startswith("deck_kong3_"):
-        args = [ deck_cli, "gateway", cmd, "--config", "/tmp/deck.yaml", "--skip-consumers", "--select-tag", select_tag]
+        args = [ deck_cli, "gateway", cmd, "--config", "/tmp/deck.yaml", "--select-tag", select_tag]
         if kong_addr:
             args.extend(["--kong-addr", kong_addr])
+        if not allow_consumers:
+            args.extend(["--skip-consumers"])
         args.append(state)
         return args
     else:

--- a/microservices/gatewayApi/v2/routes/gateway.py
+++ b/microservices/gatewayApi/v2/routes/gateway.py
@@ -163,6 +163,7 @@ def write_config(namespace: str) -> object:
     dp = get_data_plane(ns_attributes)
     kube_api_url = app.config['data_planes'][dp].get("kube-api")
     kong_addr_override = app.config['data_planes'][dp].get("kong-addr")
+    allow_consumers = app.config['data_planes'][dp].get("allow-consumers", False)
 
     # Build a list of existing hosts that are outside this namespace
     # They become reserved and any conflict will return an error
@@ -361,7 +362,7 @@ def write_config(namespace: str) -> object:
         abort_early(event_id, 'validate', namespace, jsonify(
             error="Validation Failed.", results=mask(out.decode('utf-8'))))
 
-    args = deck_cmd_sync_diff(deck_cli, cmd, selectTag, tempFolder, kong_addr_override)
+    args = deck_cmd_sync_diff(deck_cli, cmd, selectTag, tempFolder, kong_addr_override, allow_consumers)
     
     log.debug("[%s] Running %s" % (namespace, args))
     deck_run = Popen(args, stdout=PIPE, stderr=STDOUT)
@@ -477,7 +478,7 @@ def cleanup(dir_path):
         log.error("Error: %s : %s" % (dir_path, e.strerror))
 
 def validate_base_entities(yaml, ns_attributes):
-    traversables = ['_format_version', '_plugin_configs', 'services', 'upstreams', 'certificates', 'key_sets', 'keys']
+    traversables = ['_format_version', '_plugin_configs', 'services', 'upstreams', 'consumers', 'certificates', 'key_sets', 'keys']
 
     allow_protected_ns = ns_attributes.get('perm-protected-ns', ['deny'])[0] == 'allow'
     if allow_protected_ns:

--- a/microservices/gatewayApi/v2/routes/gateway.py
+++ b/microservices/gatewayApi/v2/routes/gateway.py
@@ -50,6 +50,7 @@ def delete_config(namespace: str, qualifier="") -> object:
     dp = get_data_plane(ns_attributes)
     kube_api_url = app.config['data_planes'][dp].get("kube-api")
     kong_addr_override = app.config['data_planes'][dp].get("kong-addr")
+    allow_consumers = app.config['data_planes'][dp].get("allow-consumers", False)
 
     log = app.logger
 
@@ -72,7 +73,7 @@ def delete_config(namespace: str, qualifier="") -> object:
     deck_cli = app.config['deckCLI']
 
     log.info("[%s] (%s) %s action using %s" % (namespace, deck_cli, cmd, selectTag))
-    args = deck_cmd_sync_diff(deck_cli, cmd, selectTag, tempFolder, kong_addr_override)
+    args = deck_cmd_sync_diff(deck_cli, cmd, selectTag, tempFolder, kong_addr_override, allow_consumers)
 
     log.debug("[%s] Running %s" % (namespace, args))
     deck_run = Popen(args, stdout=PIPE, stderr=STDOUT)

--- a/microservices/gatewayApi/v2/routes/gw_resources.py
+++ b/microservices/gatewayApi/v2/routes/gw_resources.py
@@ -1,0 +1,20 @@
+from flask import Blueprint, jsonify, request, Response, make_response, abort, g, current_app as app
+
+from v2.auth.auth import admin_jwt, uma_enforce
+from clients.kong import get_tagged_resources_by_ns
+
+gw_resources = Blueprint('gw_resources', 'gw_resources')
+
+@gw_resources.route('',
+           methods=['GET'], strict_slashes=False)
+@admin_jwt(None)
+@uma_enforce('namespace', 'GatewayConfig.Publish')
+def get_resources(namespace: str) -> object:
+
+    log = app.logger
+
+    log.info("Get resources for %s" % namespace)
+
+    resources = get_tagged_resources_by_ns(namespace)
+
+    return make_response(jsonify(resources))

--- a/microservices/gatewayApi/v2/routes/gw_resources.py
+++ b/microservices/gatewayApi/v2/routes/gw_resources.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, jsonify, request, Response, make_response, abort, g, current_app as app
 
 from v2.auth.auth import admin_jwt, uma_enforce
-from clients.kong import get_tagged_resources_by_ns
+from clients.kong import get_tagged_resources_by_tag
 from v2.services.namespaces import NamespaceService
 
 gw_resources = Blueprint('gw_resources', 'gw_resources')
@@ -16,13 +16,21 @@ def get_resources(namespace: str) -> object:
 
     log.info("Get resources for %s" % namespace)
 
+    # Optional query parameter for tag
+    tag = "ns.%s" % namespace
+    if request.args.get('tag'):
+        tag = request.args.get('tag')
+        # check that tag starts with ns.<namespace>
+        if not tag.startswith("ns.%s." % namespace):
+            abort(400, "Invalid tag parameter. Must start with ns.%s" % namespace)
+
     ns_svc = NamespaceService()
     ns_attributes = ns_svc.get_namespace_attributes(namespace)
 
     dp = get_data_plane(ns_attributes)
     kong_addr_override = app.config['data_planes'][dp].get("kong-addr")
 
-    resources = get_tagged_resources_by_ns(namespace, kong_addr_override)
+    resources = get_tagged_resources_by_tag(tag, kong_addr_override)
 
     return make_response(jsonify(resources))
 

--- a/microservices/gatewayApi/v2/routes/gw_resources.py
+++ b/microservices/gatewayApi/v2/routes/gw_resources.py
@@ -2,6 +2,7 @@ from flask import Blueprint, jsonify, request, Response, make_response, abort, g
 
 from v2.auth.auth import admin_jwt, uma_enforce
 from clients.kong import get_tagged_resources_by_ns
+from v2.services.namespaces import NamespaceService
 
 gw_resources = Blueprint('gw_resources', 'gw_resources')
 
@@ -15,6 +16,16 @@ def get_resources(namespace: str) -> object:
 
     log.info("Get resources for %s" % namespace)
 
-    resources = get_tagged_resources_by_ns(namespace)
+    ns_svc = NamespaceService()
+    ns_attributes = ns_svc.get_namespace_attributes(namespace)
+
+    dp = get_data_plane(ns_attributes)
+    kong_addr_override = app.config['data_planes'][dp].get("kong-addr")
+
+    resources = get_tagged_resources_by_ns(namespace, kong_addr_override)
 
     return make_response(jsonify(resources))
+
+def get_data_plane(ns_attributes):
+    default_data_plane = app.config['defaultDataPlane']
+    return ns_attributes.get('perm-data-plane', [default_data_plane])[0]

--- a/microservices/gatewayApi/v2/v2.py
+++ b/microservices/gatewayApi/v2/v2.py
@@ -8,6 +8,7 @@ from v2.routes.namespaces import ns
 from v2.routes.migrate_v1 import mg
 from v2.routes.whoami import whoami
 from v2.routes.consumers import consumers
+from v2.routes.gw_resources import gw_resources
 
 v2 = Blueprint('v2', 'v2')
 
@@ -25,6 +26,7 @@ class Register:
         app.register_blueprint(authz, url_prefix="/v2/authz")
         app.register_blueprint(ns, url_prefix="/v2/namespaces")
         app.register_blueprint(gw, url_prefix="/v2/namespaces/<string:namespace>/gateway")
+        app.register_blueprint(gw_resources, url_prefix="/v2/namespaces/<string:namespace>/resources")
         app.register_blueprint(gw_status, url_prefix="/v2/namespaces/<string:namespace>/services")
         app.register_blueprint(whoami, url_prefix="/v2/whoami")
         app.register_blueprint(mg, url_prefix="/v2/migration")


### PR DESCRIPTION
## Summary

Adds support for retrieving gateway resources by namespace and enables consumer configuration within a gateway. Also introduces per-data-plane control over whether consumers are managed by deck.

## Changes

### New: Get resources for a gateway
- Adds a new `GET /v2/namespaces/<namespace>/resources` endpoint (`v2/routes/gw_resources.py`) that returns all Kong resources tagged for the namespace (`ns.<namespace>`).
- Resource lookups honour the namespace's configured data plane, using its `kong-addr` override.

### Kong client
- Adds `get_tagged_resources_by_ns(ns, base_url)` to fetch resources via the Kong `/tags/ns.<namespace>` endpoint.
- `recurse_get_records` now accepts an optional `base_url` so requests can target a specific data plane's admin API (falls back to `kongAdminUrl` when not provided), and the `base_url` is propagated through paginated `next` calls.

### Consumers in gateway config
- `deck_cmd_sync_diff` gains an `allow_consumers` flag (default `False`). `--skip-consumers` is now only added when consumers are **not** allowed, instead of always.
- `write_config` reads `allow-consumers` from the data plane config (default `False`) and passes it through to the deck sync/diff command.
- Adds `consumers` to the list of traversable base entities in `validate_base_entities`.
