### PR TITLE
APS-4652 Pin OAS validator Spectral rulesets version

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -78,7 +78,10 @@ jobs:
         run: |
           export PATH=/root/.local/bin:$PATH
           sudo apt install -y nodejs npm
-          sudo npm install -g @stoplight/spectral-cli@6.14.2
+          sudo npm install -g \
+            @stoplight/spectral-cli@6.14.2 \
+            @stoplight/spectral-rulesets@1.22.2
+          test "$(node -p "require('/usr/local/lib/node_modules/@stoplight/spectral-rulesets/package.json').version")" = "1.22.2"
           cd microservices/csitOasValidationApi
           poetry env use python3.14
           poetry install --no-root

--- a/microservices/csitOasValidationApi/Dockerfile
+++ b/microservices/csitOasValidationApi/Dockerfile
@@ -8,8 +8,16 @@ RUN apk add --no-cache build-base libffi-dev openssl curl git bash nodejs npm
 
 RUN python -m pip install --upgrade pip
 
-# Install Spectral CLI (required for validation)
-RUN npm install -g @stoplight/spectral-cli@6.14.2
+# Install Spectral CLI (required for validation). Pin the rulesets package
+# separately because spectral-cli declares it as ">=1" and newer transitive
+# releases can change validation behaviour without changing the CLI version.
+ARG SPECTRAL_CLI_VERSION=6.14.2
+ARG SPECTRAL_RULESETS_VERSION=1.22.2
+RUN npm install -g \
+      "@stoplight/spectral-cli@${SPECTRAL_CLI_VERSION}" \
+      "@stoplight/spectral-rulesets@${SPECTRAL_RULESETS_VERSION}" && \
+    test "$(node -p "require('/usr/local/lib/node_modules/@stoplight/spectral-rulesets/package.json').version")" = \
+      "${SPECTRAL_RULESETS_VERSION}"
 
 # Install Poetry
 RUN cd /tmp && \

--- a/microservices/csitOasValidationApi/README.md
+++ b/microservices/csitOasValidationApi/README.md
@@ -75,7 +75,9 @@ sudo apt install nodejs npm
 Install Stoplight Spectral
 Requires 6.0.0 or greater
 ```bash
-sudo npm install -g @stoplight/spectral-cli@6.14.2 
+sudo npm install -g \
+  @stoplight/spectral-cli@6.14.2 \
+  @stoplight/spectral-rulesets@1.22.2
 spectral --version
 ```
 

--- a/microservices/csitOasValidationApi/tests/unit/test_spectral_runtime.py
+++ b/microservices/csitOasValidationApi/tests/unit/test_spectral_runtime.py
@@ -1,0 +1,48 @@
+"""Regression tests for the external Spectral runtime."""
+
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+def test_null_example_does_not_crash_spectral():
+    """duplicated-entry-in-enum must not dereference enum on null nodes."""
+
+    ruleset = (
+        Path(__file__).parent
+        / "resources"
+        / "github-cache"
+        / "tags"
+        / "ruleset-v1.1.0"
+        / "spectral"
+        / "sdx"
+        / "ruleset.yaml"
+    )
+    openapi_content = textwrap.dedent("""\
+        openapi: 3.0.3
+        info:
+          title: Nullable example regression
+          version: 1.0.0
+        paths:
+          /widgets:
+            get:
+              operationId: listWidgets
+              responses:
+                '200':
+                  description: Widget list
+                  content:
+                    application/json:
+                      example:
+                        nextCursor: null
+        """)
+
+    result = subprocess.run(
+        ["spectral", "lint", "--ruleset", str(ruleset), "-"],
+        input=openapi_content,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode != 2, result.stderr


### PR DESCRIPTION
## Summary

Pins the OAS validation service’s Spectral rulesets dependency so validator behaviour remains reproducible across image builds.

The validator already pinned `@stoplight/spectral-cli` to `6.14.2`, but the CLI permits any `@stoplight/spectral-rulesets` version matching `>=1`. A recent build therefore installed rulesets `1.22.6`, which contains a regression that crashes `duplicated-entry-in-enum` when an OpenAPI example contains a legitimate `null` value.

## Changes

- Pin `@stoplight/spectral-rulesets` to the last verified working version, `1.22.2`.
- Define explicit CLI and rulesets versions in the validator Dockerfile.
- Assert the installed rulesets version during image builds.
- Install and verify the same versions in CI.
- Add a regression test covering a nullable OpenAPI response example.
- Update the validator README with the complete Spectral installation command.

## Verification

- GitHub Actions passed all service tests, including the new nullable-example regression test.
- SonarCloud checks passed.
- The multi-architecture validator image was published for `linux/amd64` and `linux/arm64`.
- The branch image was deployed temporarily to DEV and verified to contain:
  - Spectral CLI `6.14.2`
  - Spectral rulesets `1.22.2`
- The unchanged Widget API OAD subsequently returned HTTP 200 with `valid: true` and zero validation findings.
- SDX service registration using that OAD completed successfully.

GitHub Actions: https://github.com/bcgov/gwa-api/actions/runs/30408686622

## Operational note

The shared DEV workflow considers changes to `.github/workflows/dev.yml` build-worthy for multiple GWA services. As a result, the branch workflow also produced branch-tagged images for other microservices, but it did not deploy them.

## Upstream reference

The failure is associated with the Spectral null-guard regression addressed by:

https://github.com/stoplightio/spectral/pull/2963